### PR TITLE
Don't load bad data on standalone startup

### DIFF
--- a/Source/DSP/GranularSynth.cpp
+++ b/Source/DSP/GranularSynth.cpp
@@ -303,6 +303,10 @@ void GranularSynth::getStateInformation(juce::MemoryBlock& destData) {
 }
 
 void GranularSynth::setStateInformation(const void* data, int sizeInBytes) {
+  if (this->wrapperType == GranularSynth::WrapperType::wrapperType_Standalone) {
+    return;  // reloadPluginState() can try loading old/bad/stale info and crash at launch
+  }
+
   auto xml = getXmlFromBinary(data, sizeInBytes);
 
   if (xml != nullptr) {


### PR DESCRIPTION
As I switch around branchs/commit, I find the standalone attempt to load the previous state annoying, and sometimes causing a segfault when I try to just start the program